### PR TITLE
feat(methods): onResult callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "asteroid",
+  "name": "backlog-asteroid",
   "version": "2.0.3",
-  "description": "Alternative Meteor client",
+  "description": "Temporary clone of asteroid",
   "main": "lib/asteroid.js",
   "scripts": {
     "build": "babel src --out-dir lib",

--- a/src/base-mixins/methods.js
+++ b/src/base-mixins/methods.js
@@ -12,9 +12,19 @@
 */
 
 export function apply (method, params) {
+    let onResult = params && params[params.length - 1];
+    if (typeof onResult === "function") {
+        params.pop();
+    } else {
+        onResult = undefined;
+    }
     return new Promise((resolve, reject) => {
         const id = this.ddp.method(method, params);
-        this.methods.cache[id] = {resolve, reject};
+        this.methods.cache[id] = {
+            resolve,
+            reject,
+            onResult,
+        };
     });
 }
 
@@ -64,6 +74,9 @@ export function init () {
             // result and resolve the promise with this result when the
             // `updated` event is emitted
             this.methods.cache[id].result = result;
+            if (this.methods.cache[id].onResult) {
+                this.methods.cache[id].onResult(result);
+            }
             return;
         }
         delete this.methods.cache[id];

--- a/test/unit/base-mixins/methods.js
+++ b/test/unit/base-mixins/methods.js
@@ -111,6 +111,26 @@ describe("`methods` mixin", () => {
             expect(reject).to.have.been.calledWith({});
         });
 
+        it("calls onResult callback", () => {
+            const onResult = sinon.spy();
+            const result = {foo: "bar"};
+            const instance = {ddp: new EventEmitter()};
+            init.call(instance);
+            const resolve = sinon.spy();
+            const reject = sinon.spy();
+            instance.methods.cache["id"] = {
+                resolve,
+                reject,
+                onResult,
+            };
+            instance.ddp.emit("result", {
+                id: "id",
+                result
+            });
+            expect(onResult.calledOnce).to.equal(true);
+            expect(onResult.firstCall.args[0]).to.deep.equal(result);
+        });
+
     });
 
     describe("`apply` method", () => {
@@ -119,7 +139,10 @@ describe("`methods` mixin", () => {
             const instance = {
                 ddp: {
                     method: sinon.spy()
-                }
+                },
+                methods: {
+                    cache: {},
+                },
             };
             const ret = apply.call(instance);
             expect(ret).to.be.an.instanceOf(Promise);
@@ -130,10 +153,27 @@ describe("`methods` mixin", () => {
             const instance = {
                 ddp: {
                     method: sinon.spy()
-                }
+                },
+                methods: {
+                    cache: {},
+                },
             };
             apply.call(instance, "method", [{}]);
             expect(instance.ddp.method).to.have.been.calledWith("method", [{}]);
+        });
+
+        it("should store onResult callback", () => {
+            const onResult = () => "bar";
+            const instance = {
+                ddp: {
+                    method: sinon.spy(() => "method-id-1")
+                },
+                methods: {
+                    cache: {},
+                },
+            };
+            apply.call(instance, "method", ["foo", onResult]);
+            expect(instance.methods.cache["method-id-1"].onResult).to.equal(onResult);
         });
 
     });


### PR DESCRIPTION
#### Summary
Add support for passing an additional callback when calling `asteroid.call` which will be called when the `result` event arrives for that method.
This allows you to optimistically ignore any "side-effects" of the meteor method that you already made yourself optimistically.

#### Caveats
This does not allow you to compare the outcome of the meteor method with your own optimistic updates. (This is how Meteor does it internally)